### PR TITLE
Fixed switching if more than one file pair open.

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -8,11 +8,6 @@ function! FindInc()
 endfun
 
 function! CurtineIncSw()
-  if exists("t:IncSw")
-    e#
-    return 0
-  endif
-
   if match(expand("%"), '\.c') > 0
     let t:IncSw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
   elseif match(expand("%"), "\\.h") > 0


### PR DESCRIPTION
The previous file is not the associated file if there is more than one buffer open.
For instance: 
    open a.h
    CurtineIncSw() switches to a.c
    open to b.h
    CurtineIncSw() switches to a.c, rather than b.c

Removing this optimization ensures that we always pick the associated file, rather than the previously open file.