### PR TITLE
Added Optimizations

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -8,11 +8,6 @@ function! FindInc()
 endfun
 
 function! CurtineIncSw()
-  if exists("t:IncSw")
-    e#
-    return 0
-  endif
-
   if match(expand("%"), '\.c') > 0
     let t:IncSw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
   elseif match(expand("%"), "\\.h") > 0

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,8 +1,14 @@
 function! FindInc()
   let dirname=fnamemodify(expand("%:p"), ":h")
-  let cmd="find . " . dirname . " -type f -iname " . t:IncSw . " | head -n1 | tr -d '\n'"
-
-  let findRes=system(cmd)
+  let findRes=""
+  let targetFile=t:IncSw
+  for location in [dirname, '.' ]
+    let cmd="find " . location . " -type f -iname " . targetFile . " -print -quit | tr -d '\n'"
+    let findRes=system(cmd)
+    if filereadable(findRes)
+      break
+    endif
+  endfor
 
   exe "e " findRes
 endfun

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,9 +1,9 @@
 function! FindInc()
   let dirname=fnamemodify(expand("%:p"), ":h")
   let findRes=""
-  let targetFile=t:IncSw
+  let targetFile=b:IncSw
   for location in [dirname, '.' ]
-    let cmd="find " . location . " -type f -iname " . targetFile . " -print -quit | tr -d '\n'"
+    let cmd="find " . location . " -type f -iname " . targetFile . " -print -quit"
     let findRes=system(cmd)
     if filereadable(findRes)
       break
@@ -14,10 +14,14 @@ function! FindInc()
 endfun
 
 function! CurtineIncSw()
+  if exists("b:IncSw")
+    e#
+    return 0
+  endif
   if match(expand("%"), '\.c') > 0
-    let t:IncSw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
+    let b:IncSw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
   elseif match(expand("%"), "\\.h") > 0
-    let t:IncSw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
+    let b:IncSw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
   endif
 
   call FindInc()


### PR DESCRIPTION
Added back optimizations that were removed in #8, making use of buffer internal variables instead. These should continue to work for people who use tabs as well.
Made `find` explicitly return after the first found match, instead of relying on `head -n1`.
Changed to look in the current directory first, to aid users that have a large repo, but expect the corresponding file to be close, such as in #6.