### PR TITLE
Fix zsh find expression expansion

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,7 +1,7 @@
 function! FindInc()
   let dirname=fnamemodify(expand("%:p"), ":h")
   let target_file=b:inc_sw
-  let cmd="find " . dirname . " . -type f -iname " . target_file . " -print -quit"
+  let cmd="find " . dirname . " . -type f -iname \"" . target_file . "\" -print -quit"
   let find_res=system(cmd)
   if filereadable(find_res)
     return 0


### PR DESCRIPTION
This fixes issue #7 

I have tested this using zsh, and in limited capacity also made sure it works with `/bin/sh` and `/bin/bash` by running vim like this:
`SHELL=/bin/sh vim` and `SHELL=/bin/bash vim` and it works