### PR TITLE
no error messages pop out when try to toggle invalid files

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -11,10 +11,6 @@ function! FindInc()
 endfun
 
 function! CurtineIncSw()
-  if exists("b:inc_sw")
-    e#
-    return 0
-  endif
   if match(expand("%"), '\.c') > 0
     let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
     call FindInc()

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,29 +1,27 @@
-function! FindInc()
+function! FindInc(inc_sw)
   let dirname=fnamemodify(expand("%:p"), ":h")
-  let target_file=b:inc_sw
+  let target_file=a:inc_sw
   let cmd="find " . dirname . " . -type f -iname \"" . target_file . "\" -print -quit"
   let b:find_res=system(cmd)
-  if filereadable(b:find_res)
-    return 0
-  endif
-
-  exe "e " b:find_res
 endfun
 
 function! CurtineIncSw()
-  "if already found previously, directly open the matched file
-  if exists("b:find_res")
-     exe "e " b:find_res
-  " otherwise try to find the matched file
-  else
-      if match(expand("%"), '\.c') > 0
-        let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
-        call FindInc()
-      elseif match(expand("%"), "\\.h") > 0
-        let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
-        call FindInc()
-      endif
+
+  " not found previously
+  if exists("b:find_res") == 0
+    if match(expand("%"), '\.c') > 0
+      let inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
+      call FindInc(inc_sw)
+    elseif match(expand("%"), "\\.h") > 0
+      let inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
+      call FindInc(inc_sw)
+    else
+      return 0
+    endif
   endif
+
+  " open the matched file
+  exe "e " b:find_res
 
 endfun
 

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -19,6 +19,9 @@ function! CurtineIncSw()
     let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
   elseif match(expand("%"), "\\.h") > 0
     let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
+  " if the file is not .c or .h, just be silent
+  else
+    return 0
   endif
 
   call FindInc()

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -2,21 +2,27 @@ function! FindInc()
   let dirname=fnamemodify(expand("%:p"), ":h")
   let target_file=b:inc_sw
   let cmd="find " . dirname . " . -type f -iname \"" . target_file . "\" -print -quit"
-  let find_res=system(cmd)
-  if filereadable(find_res)
+  let b:find_res=system(cmd)
+  if filereadable(b:find_res)
     return 0
   endif
 
-  exe "e " find_res
+  exe "e " b:find_res
 endfun
 
 function! CurtineIncSw()
-  if match(expand("%"), '\.c') > 0
-    let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
-    call FindInc()
-  elseif match(expand("%"), "\\.h") > 0
-    let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
-    call FindInc()
+  "if already found previously, directly open the matched file
+  if exists("b:find_res")
+     exe "e " b:find_res
+  " otherwise try to find the matched file
+  else
+      if match(expand("%"), '\.c') > 0
+        let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
+        call FindInc()
+      elseif match(expand("%"), "\\.h") > 0
+        let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
+        call FindInc()
+      endif
   endif
 
 endfun

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -17,13 +17,11 @@ function! CurtineIncSw()
   endif
   if match(expand("%"), '\.c') > 0
     let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
+    call FindInc()
   elseif match(expand("%"), "\\.h") > 0
     let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
-  " if the file is not .c or .h, just be silent
-  else
-    return 0
+    call FindInc()
   endif
 
-  call FindInc()
 endfun
 


### PR DESCRIPTION
Hi,

I like your plugin to toggle between .c and .h files in Vim. Really handy for c dev !
But when i accidentally and wrongly toggle an invalid file (not .c or .h files, such as makefile), it gives me a big error message in vim.
I update the plugin to keep it silent in this case.

Hopefully you also think that this PR improves this plugin :)

Qiaowei