### PR TITLE
fix corner case where filename.cpp.o matches

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,7 +1,9 @@
 function! FindInc()
   let dirname=fnamemodify(expand("%:p"), ":h")
   let target_file=b:inc_sw
-  let cmd="find " . dirname . " . -type f -iname \"" . target_file . "\" -print -quit"
+  " At this point cmd might evaluate to something of the format:
+  " /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
+  let cmd="find " . dirname . " . -type f -iregex \""  . target_file . "\" -print -quit"
   let find_res=system(cmd)
   if filereadable(find_res)
     return 0
@@ -16,9 +18,9 @@ function! CurtineIncSw()
     return 0
   endif
   if match(expand("%"), '\.c') > 0
-    let b:inc_sw=substitute(expand("%:t"), '\.c\(.*\)', '.h*', "")
+    let b:inc_sw=substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
   elseif match(expand("%"), "\\.h") > 0
-    let b:inc_sw=substitute(expand("%:t"), '\.h\(.*\)', '.c*', "")
+    let b:inc_sw=substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
   endif
 
   call FindInc()


### PR DESCRIPTION
Hi, I noticed a corner case - if I have a file filename.cpp.o which is a build output for me it will switch to this file instead.

I thought of a few solutions:

- Use vim's wildignore which usually includes your build path and is generally useful
- pipe the find through grep -v instead of -print -quit
- specifically match on all possible file endings, .cpp .cxx .c etc.

But I think this one is fine. It now cannot match XXX.cpp.XXX or the like.