### PR TITLE
Fixed corner case when opening other files

### DIFF
--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -1,28 +1,37 @@
-function! FindInc()
-  let dirname=fnamemodify(expand("%:p"), ":h")
-  let target_file=b:inc_sw
-  " At this point cmd might evaluate to something of the format:
-  " /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
-  let cmd="find " . dirname . " . -type f -iregex \""  . target_file . "\" -print -quit"
-  let find_res=system(cmd)
-  if filereadable(find_res)
-    return 0
-  endif
-
-  exe "e " find_res
-endfun
-
 function! CurtineIncSw()
-  if exists("b:inc_sw")
-    e#
-    return 0
-  endif
   if match(expand("%"), '\.c') > 0
-    let b:inc_sw=substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
+    let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
   elseif match(expand("%"), "\\.h") > 0
-    let b:inc_sw=substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
+    let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
   endif
 
-  call FindInc()
+  if exists("b:previous_file") && b:previous_file == l:next_file
+    e#
+  else
+    let l:directory_name = fnamemodify(expand("%:p"), ":h")
+    " At this point cmd might evaluate to something of the format:
+    " /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
+    let cmd="find " . l:directory_name . " . -type f -iregex \""  . l:next_file . "\" -print -quit | head -n1 | tr -d '\n'"
+    let l:result = system(cmd)
+
+    if filereadable(l:result)
+      exe "e " l:result
+    endif
+  endif
 endfun
 
+function! GetCurrentFile()
+  if exists("b:current_file")
+    let b:previous_file = b:current_file
+  endif
+
+  if match(expand("%"), '\.c') > 0
+    let b:current_file = substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.c[a-z]*', "")
+  elseif match(expand("%"), "\\.h") > 0
+    let b:current_file = substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.h[a-z]*', "")
+  endif
+endfun
+
+augroup CurtineIncSwCurrentFile
+  autocmd BufWinEnter * call GetCurrentFile()
+augroup END

--- a/plugin/CurtinIncSw.vim
+++ b/plugin/CurtinIncSw.vim
@@ -11,8 +11,12 @@ function! CurtineIncSw()
     let l:directory_name = fnamemodify(expand("%:p"), ":h")
     " At this point cmd might evaluate to something of the format:
     " /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
-    let cmd="find " . l:directory_name . " . -type f -iregex \""  . l:next_file . "\" -print -quit | head -n1 | tr -d '\n'"
-    let l:result = system(cmd)
+    let l:cmd="find " . l:directory_name . " . -type f -iregex \""  . l:next_file . "\" -print -quit"
+
+    " The substitute gets rid of the new line at the end of the result. The
+    " function `filereadable` does not like the newline that `find` puts at
+    " the end of the result and will not acknowledge that the file exists.
+    let l:result = substitute(system(l:cmd), '\n', '', '')
 
     if filereadable(l:result)
       exe "e " l:result


### PR DESCRIPTION
Hi @ericcurtin,

Thanks for writing this plugin! I have found it pretty useful.

I have encountered an issue when I have been jumping around in a code base. After switching from a.c to a.h files, opening a file, b.h, with no corresponding .c file, trying to navigate to the corresponding b.c, and navigating back to a.h files, CurtineIncSw will rotate between the b.c and a.h.

An example scenario is below:

```
open a.c
CurtineIncSw() switches to a.h
CurtineIncSw() switches to a.c
find b.c (which has no .h)
CurtineIncSw() does nothing
CTRL + O back to a.c
CurtineIncSw() switches to b.c
CurtineIncSw() switches to a.c
etc...
```

This pull request should fix the issue.

I hope you find this PR to be helpful.