### PR TITLE
Add ada support

### DIFF
--- a/plugin/CurtineIncSw.vim
+++ b/plugin/CurtineIncSw.vim
@@ -3,6 +3,10 @@ function! CurtineIncSw()
     let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
   elseif match(expand("%"), "\\.h") > 0
     let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
+  elseif match(expand("%"), '\.ads') > 0
+    let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.ads\(.*\)', '.adb[a-z]*', "")
+  elseif match(expand("%"), "\\.adb") > 0
+    let l:next_file = substitute(".*\\\/" . expand("%:t"), '\.adb\(.*\)', '.ads[a-z]*', "")
   endif
 
   if exists("b:previous_file") && b:previous_file == l:next_file


### PR DESCRIPTION
I know this is really lazy, further duplicating the two lines of code that already had a lot of duplication. But I don't care. This just works, for switching between .adb and .ads, the Ada equivalent header / body files.

I'm not going to be making this more robust, because the real solution is probably to grok [vim-projectionist](https://github.com/tpope/vim-projectionist), but I tried and gave up.