### PR TITLE
Fix Ada support, search cache, and failure cases

### DIFF
--- a/plugin/CurtineIncSw.vim
+++ b/plugin/CurtineIncSw.vim
@@ -1,33 +1,56 @@
-function! FindInc()
+" Search for alternative_filename_regex in the dir of the current file
+" if found, returns v:true and sets b:inc_sw to the full path
+function! FindInc(alternative_filename_regex)
   let dirname=fnamemodify(expand("%:p"), ":h")
-  let target_file=b:inc_sw
+  let target_file=a:alternative_filename_regex
   " At this point cmd might evaluate to something of the format:
-  " /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
+  " find /Users/person/ . -type f -iregex ".*\/test_class.h[a-z]*" -print -quit
   let cmd="find " . dirname . " . -type f -iregex \""  . target_file . "\" -print -quit"
-  let find_res=system(cmd)
-  if filereadable(find_res)
-    return 0
+  let find_res=systemlist(cmd)
+  if len(find_res) == 0
+    return v:false
   endif
-
-  exe "e " find_res
+  let first_result=find_res[0]
+  if filereadable(first_result)
+    " Found a result matching the regex
+    let b:inc_sw=first_result
+    return v:true
+  endif
+  return v:false
 endfun
 
+" If a header or body is open, open the other one if found
+" returns v:true on success,
+" otherwise returns v:false and does nothing
 function! CurtineIncSw()
-  if exists("b:inc_sw")
-    e#
-    return 0
-  endif
-  if match(expand("%"), '\.c') > 0
-    let b:inc_sw = substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
-  elseif match(expand("%"), "\\.h") > 0
-    let b:inc_sw = substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
-  elseif match(expand("%"), '\.ads') > 0
-    let l:inc_sw = substitute(".*\\\/" . expand("%:t"), '\.ads\(.*\)', '.adb[a-z]*', "")
-  elseif match(expand("%"), "\\.adb") > 0
-    let l:inc_sw = substitute(".*\\\/" . expand("%:t"), '\.adb\(.*\)', '.ads[a-z]*', "")
+  if exists("b:inc_sw") && filereadable(b:inc_sw)
+    " Use cached filename of alternative
+    execute "e " .. b:inc_sw
+    return v:true
   endif
 
-  call FindInc()
+  let alternative = v:null
+  if match(expand("%"), '\.c') > 0
+    let alternative = substitute(".*\\\/" . expand("%:t"), '\.c\(.*\)', '.h[a-z]*', "")
+  elseif match(expand("%"), "\\.h") > 0
+    let alternative = substitute(".*\\\/" . expand("%:t"), '\.h\(.*\)', '.c[a-z]*', "")
+  elseif match(expand("%"), '\.ads') > 0
+    let alternative = substitute(".*\\\/" . expand("%:t"), '\.ads\(.*\)', '.adb', "")
+  elseif match(expand("%"), "\\.adb") > 0
+    let alternative = substitute(".*\\\/" . expand("%:t"), '\.adb\(.*\)', '.ads', "")
+  endif
+
+  if alternative is v:null
+    " there is no alternative for this kind of file
+    return v:false
+  endif
+
+  let success = FindInc(alternative)
+  if success
+    execute "e " .. b:inc_sw
+    return v:true
+  endif
+  return v:false
 endfun
 
 au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif


### PR DESCRIPTION
This fixes #17 

Also return v:true on success and v:false on failure now. Added comments to the functions.

Most of these bugs stem from the earlier e# fix:

- Ada support was broken because of not updating the b:inc_sw buffer var
- result from find was always returning something unreadable due to having '^@' appended. Fix is to use systemlist instead and check length of results
- e# was never the right thing to do; intention was to use a cached result, but doing e# could swap to totally unrelated files, if you had just opened, from an unrelated file, a file which already had a cached alternate file available. Instead, use the actual cached result
- check again that the cached result is readable - it could have been moved or deleted, invalidating the result
- another edge case went wrong; when the filetype doesn't have any defined regex for the "alternate" - now we gracefully return v:false without throwing errors about undefined variables